### PR TITLE
Vrf id to str

### DIFF
--- a/cgn_ec_api/models/generic.py
+++ b/cgn_ec_api/models/generic.py
@@ -18,7 +18,7 @@ class MetricBaseRead(BaseModel):
 class NATSessionMappingRead(MetricBaseRead):
     host: IPv4Address
     event: int
-    vrf_id: int | None = None
+    vrf_id: str | None = None
     protocol: int
     src_ip: IPv4Address
     src_port: int
@@ -31,7 +31,7 @@ class NATSessionMappingRead(MetricBaseRead):
 class NATAddressMappingRead(MetricBaseRead):
     host: IPv4Address
     event: int
-    vrf_id: int | None = None
+    vrf_id: str | None = None
     src_ip: IPv4Address
     x_ip: IPv4Address
 
@@ -39,7 +39,7 @@ class NATAddressMappingRead(MetricBaseRead):
 class NATPortMappingRead(MetricBaseRead):
     host: IPv4Address
     event: int
-    vrf_id: int | None = None
+    vrf_id: str | None = None
     protocol: int
     src_ip: IPv4Address
     src_port: int
@@ -50,7 +50,7 @@ class NATPortMappingRead(MetricBaseRead):
 class NATPortBlockMappingRead(MetricBaseRead):
     host: IPv4Address
     event: int
-    vrf_id: int | None = None
+    vrf_id: str | None = None
     src_ip: IPv4Address
     x_ip: IPv4Address
     start_port: int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cgn-ec-api"
-version = "0.4.0"
+version = "0.5.0"
 description = "CGN-EC API"
 authors = ["BSpendlove <8687668+BSpendlove@users.noreply.github.com>"]
 readme = "README.md"


### PR DESCRIPTION
⚠️ **BREAKING CHANGE – Manual DB Migration Required** ⚠️

This merge request modifies the schema of the following tables:

- `port_mapping`
- `port_block_mapping`
- `session_mapping`
- `address_mapping`

🔧 Specifically, the `vrf_id` column is being changed from `SMALLINT` ➜ `VARCHAR(32)` across all of them.

> **Action Required**: Run the following SQL **before deploying** this version to avoid runtime errors:

```sql
ALTER TABLE port_mapping
  ALTER COLUMN vrf_id TYPE VARCHAR(32) USING vrf_id::VARCHAR(32);

ALTER TABLE port_block_mapping
  ALTER COLUMN vrf_id TYPE VARCHAR(32) USING vrf_id::VARCHAR(32);

ALTER TABLE session_mapping
  ALTER COLUMN vrf_id TYPE VARCHAR(32) USING vrf_id::VARCHAR(32);

ALTER TABLE address_mapping
  ALTER COLUMN vrf_id TYPE VARCHAR(32) USING vrf_id::VARCHAR(32);
  ```