### PR TITLE
Add extra api params

### DIFF
--- a/cgn_ec_api/crud/base.py
+++ b/cgn_ec_api/crud/base.py
@@ -56,15 +56,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
             query = select(self.model)
 
         if params is not None:
-            skip = params.skip
-            limit = params.limit
             query = params.apply_to_query(query, self.model)
-
-        if skip > 0:
-            query = query.offset(skip)
-
-        if limit > 0:
-            query = query.limit(limit)
 
         result = await db.exec(query)
         return result.all()

--- a/cgn_ec_api/crud/base.py
+++ b/cgn_ec_api/crud/base.py
@@ -46,6 +46,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
             query:          Select Query statement.
             skip:           Skip entries in database.
             limit:          Limit database results.
+            order_by:       Adjust ordering of results.
         """
         if query is not None and not isinstance(query, (Select, SelectOfScalar)):
             raise TypeError(


### PR DESCRIPTION
This allows specifying `order_by` and `event` params.

`order_by` defaults to `timestamp` which should match the original intention, but could instead be `timestamp desc` for example.

It was previously using `created_at` in the code which isn't valid in the schema, but was never actually applying it anywhere that I could see, the default could be changed to None to match the old behaviour exactly if desired.

I also removed some unneeded things in `base.py` now that `apply_to_query` handles skip and limit