### PR TITLE
Make limit definition consistent (and thus actually allow a limit of 1)

### DIFF
--- a/cgn_ec_api/models/query.py
+++ b/cgn_ec_api/models/query.py
@@ -11,7 +11,7 @@ ModelType = TypeVar("ModelType", bound=SQLModel)
 
 
 class QueryParams(BaseModel):
-    limit: int = Field(100, gt=1, le=214457)
+    limit: int = Field(100, gt=0, le=100)
     skip: int = Field(0, ge=0)
     event: int | None = Field(None, ge=1, nullable=True)
     order_by: str = Field("timestamp", schema_extra={'pattern': r"^\w+( (asc|desc))?$"})


### PR DESCRIPTION
`limit` was defined in 2 places as either `Field(100, gt=1, le=214457)` or `Field(100, gt=0, le=100)`

This corrects the first one to the latter, which also fixes an error where limit had to be 2 or higher.